### PR TITLE
Closes issue #17 Fixing sporadic restore failures for blueprint

### DIFF
--- a/lib/agent/backuprestore.js
+++ b/lib/agent/backuprestore.js
@@ -125,9 +125,9 @@ function getLastOperation(operation) {
   return Promise
     .all([
       fs.readFileAsync(`${paths.last_operation}/${operation}.lastoperation.json`, 'utf8'),
-      fs.readFileAsync(`${paths.logs}/${operation}.output.json`, 'utf8')
+      operation === 'backup' ? fs.readFileAsync(`${paths.logs}/${operation}.output.json`, 'utf8') : Promise.resolve({})
     ])
-    .spread((data, jsonOutput) => _.isEmpty(data) ? lastOperationStateError : _.assign(JSON.parse(data), JSON.parse(jsonOutput)))
+    .spread((data, jsonOutput) => _.isEmpty(data) ? lastOperationStateError : ( operation === 'backup' ? _.assign(JSON.parse(data), JSON.parse(jsonOutput)) : JSON.parse(data) ))
     .catch(err => {
       logger.agent.error(`Could not retrieve the last ${operation} state.`);
       logger.agent.error(err.message);


### PR DESCRIPTION
Description: Restore of blueprint used to read restore.output.json
and failed due to sporadic non-existence of this file. Since, this
file is of no consequence to restore operation and was present to
maintain generic functionality, now, not reading this file for
restore operation.