### PR TITLE
Support Backup and Restore for GCP

### DIFF
--- a/backuprestore/backup.py
+++ b/backuprestore/backup.py
@@ -41,7 +41,7 @@ def main():
                 iaas_client.exit('Could not find the snapshot of the persistent volume {}.'
                                  .format(DIRECTORY_PERSISTENT))
 
-            if landscape != 'Aws' and landscape != 'Azure':
+            if landscape != 'Aws' and landscape != 'Azure' and landscape != 'Gcp':
                 # +-> Create a volume from this snapshot whose contents will be backed-up
                 volume_snapshot = iaas_client.create_volume(
                     snapshot_store.size, snapshot_store.id)
@@ -168,7 +168,7 @@ def main():
                     iaas_client.exit(
                         'Could not upload the tarball {}.'.format(metadata_files_path))
 
-            if landscape == 'Azure':
+            if landscape == 'Azure' or landscape == 'Gcp':
                 with open(metadata_files_path, 'w') as f:
                     f.write(json.dumps(
                         {'snapshotId': snapshot_store.id}))
@@ -179,7 +179,7 @@ def main():
                         'Could not upload the tarball {}.'.format(metadata_files_path))
 
             # +-> Delete the snapshot of the persistent volume
-            if landscape != 'Azure' and not iaas_client.delete_snapshot(snapshot_store.id):
+            if landscape != 'Azure' and landscape != 'Gcp' and not iaas_client.delete_snapshot(snapshot_store.id):
                 iaas_client.exit(
                     'Could not delete the snapshot with id {}.'.format(snapshot_store.id))
 
@@ -187,7 +187,7 @@ def main():
             # +-> Stop the service job
             iaas_client.stop_service_job()
 
-            if landscape != 'Aws' and landscape != 'Azure':
+            if landscape != 'Aws' and landscape != 'Azure' and landscape != 'Gcp':
                 # +-> Create a volume where the encrypted tarballs/files will be stored on (to be uploaded)
                 volume_uploads = iaas_client.create_volume(
                     volume_persistent.size)
@@ -257,7 +257,7 @@ def main():
                     iaas_client.exit(
                         'Could not delete the upload volume with id {}.'.format(volume_uploads.id))
 
-            if landscape == 'Aws' or landscape == 'Azure':
+            if landscape == 'Aws' or landscape == 'Azure' or landscape == 'Gcp':
                 snapshot_store = None
                 if landscape == 'Aws':
                     # +-> Copy Snapshot Function to encrypt the Snapshot
@@ -266,7 +266,7 @@ def main():
                     if not snapshot_store:
                         iaas_client.exit('Could not create the encrypted copy of the snapshot {}.'
                                          .format(DIRECTORY_PERSISTENT))
-                if landscape == 'Azure':
+                if landscape == 'Azure' or landscape == 'Gcp':
                     # +-> Create a snapshot of the persistent volume
                     snapshot_store = iaas_client.create_snapshot(
                         volume_persistent.id)

--- a/backuprestore/restore.py
+++ b/backuprestore/restore.py
@@ -33,8 +33,7 @@ def main():
             iaas_client.exit(
                 'Could not find the persistent volume attached to this instance.')
 
-
-        if landscape != 'Aws' and landscape != 'Azure':
+        if landscape != 'Aws' and landscape != 'Azure' and landscape != 'Gcp':
             # +-> Create a volume where the downloaded blobs will be stored on
             volume_downloads = iaas_client.create_volume(
                 volume_persistent.size)
@@ -109,7 +108,7 @@ def main():
                 iaas_client.exit(
                     'Could not delete the download volume with id {}.'.format(volume_downloads.id))
 
-        if landscape == 'Aws' or landscape == 'Azure':
+        if landscape == 'Aws' or landscape == 'Azure' or landscape == 'Gcp':
             # get sanpshot id from service metadata stored in blobstore
             if not iaas_client.download_from_blobstore('{}/{}'.format(backup_guid, metadata_files_name), metadata_files_path):
                 iaas_client.exit(
@@ -165,11 +164,12 @@ def main():
             if os.listdir('{}/blueprint/files/'.format(DIRECTORY_DOWNLOADS)) != []:
                 if not iaas_client.copy_directory(
                     '{}/blueprint/files/*'.format(DIRECTORY_DOWNLOADS),
-                    '{}/blueprint/files'.format(DIRECTORY_PERSISTENT)):
+                        '{}/blueprint/files'.format(DIRECTORY_PERSISTENT)):
                     iaas_client.exit('Could not copy from {}/{} to the persistent volume.'
-                                 .format(DIRECTORY_DOWNLOADS, DIRECTORY_PERSISTENT))
+                                     .format(DIRECTORY_DOWNLOADS, DIRECTORY_PERSISTENT))
             else:
-                iaas_client.logger.info('Skipping copy since backup directory was empty')
+                iaas_client.logger.info(
+                    'Skipping copy since backup directory was empty')
             # +-> Start the service job
             iaas_client.start_service_job()
 

--- a/lib/agent/backuprestore.js
+++ b/lib/agent/backuprestore.js
@@ -68,7 +68,12 @@ function startBackup(params) {
     .assign(_
       .pick(iaasCredentials, iaasSpecificParams[iaasCredentials.name])
     )
-    .map((value, key) => `--${key}=${value}`)
+    .map((value, key) => {
+      if (_.isObject(value)) {
+        value = JSON.stringify(value);
+      }
+      return `--${key}=${value}`;
+    })
     .value();
 
   const spawnParameters = _(paths.backup)
@@ -104,7 +109,12 @@ function startRestore(params) {
     .assign(_
       .pick(iaasCredentials, iaasSpecificParams[iaasCredentials.name])
     )
-    .map((value, key) => `--${key}=${value}`)
+    .map((value, key) => {
+      if (_.isObject(value)) {
+        value = JSON.stringify(value);
+      }
+      return `--${key}=${value}`;
+    })
     .value();
 
   const spawnParameters = _(paths.restore)
@@ -131,7 +141,7 @@ function getLastOperation(operation) {
       fs.readFileAsync(`${paths.last_operation}/${operation}.lastoperation.json`, 'utf8'),
       operation === 'backup' ? fs.readFileAsync(`${paths.logs}/${operation}.output.json`, 'utf8') : Promise.resolve({})
     ])
-    .spread((data, jsonOutput) => _.isEmpty(data) ? lastOperationStateError : ( operation === 'backup' ? _.assign(JSON.parse(data), JSON.parse(jsonOutput)) : JSON.parse(data) ))
+    .spread((data, jsonOutput) => _.isEmpty(data) ? lastOperationStateError : (operation === 'backup' ? _.assign(JSON.parse(data), JSON.parse(jsonOutput)) : JSON.parse(data)))
     .catch(err => {
       logger.agent.error(`Could not retrieve the last ${operation} state.`);
       logger.agent.error(err.message);

--- a/lib/agent/backuprestore.js
+++ b/lib/agent/backuprestore.js
@@ -41,6 +41,10 @@ const iaasSpecificParams = {
     'tenant_id',
     'storageAccount',
     'storageAccessKey'
+  ],
+  gcp: [
+    'projectId',
+    'credentials'
   ]
 };
 


### PR DESCRIPTION
- Added conditions to handle GCP landscape in backup.py and restore.py
- Added GCP iaasSpecificParams backuprestore.js
- Also, GCP credentials are json object unlike simple key value pair in other IaaS. So, it is handled to send a string.

For more details, look at [issues-19](https://github.com/cloudfoundry-incubator/service-fabrik-blueprint-service/issues/19)